### PR TITLE
Add AboutLibraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,4 @@ Name | Repository | License
 [Joda Time Android](https://github.com/dlew/joda-time-android) | https://github.com/dlew/joda-time-android | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 [Bolts](https://github.com/BoltsFramework/Bolts-Android) | https://github.com/BoltsFramework/Bolts-Android | [BSD](https://en.wikipedia.org/wiki/BSD_licenses)
 [Secure Preference Manager](http://prashantsolanki3.github.io/Secure-Pref-Manager/) | http://prashantsolanki3.github.io/Secure-Pref-Manager/ | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
+[AboutLibraries](https://mikepenz.github.io/AboutLibraries/) | https://github.com/mikepenz/AboutLibraries | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Add AboutLibraries, a neat library that autodetects libraries installed and creates an about dialog to fulfill license requirements.

I think this fits better in here than in the UI repo, and I think it would be useful for people to be made more aware of this neat little library.