### PR TITLE
Add GalleryImageSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Name | Repository | License
 [Picasso](http://square.github.io/picasso) | https://github.com/square/picasso | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 [Universal Image Loader](https://github.com/nostra13/Android-Universal-Image-Loader) | https://github.com/nostra13/Android-Universal-Image-Loader | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 [Fresco](http://frescolib.org) | https://github.com/facebook/fresco | [BSD License](https://github.com/facebook/fresco/blob/master/LICENSE)
+[GalleryImageSelector](https://github.com/niedev/GalleryImageSelector) | https://github.com/niedev/GalleryImageSelector | [Apache License v2](https://github.com/niedev/GalleryImageSelector/blob/master/LICENSE)
 ## Drawable
 Name | Repository | License
 --- | --- | ---


### PR DESCRIPTION
Add GalleryImageSelector to Image Loader.

The GalleryImageSelector is a library that allows you to pick an image from gallery, crop it and save it in an internal file that can be accessed from the GalleryImageSelector class (via the static method GalleryImageSelector.getSavedImage).

The library is highly optimized (fixes a lot of bugs including the rotation bug) and can work with a variety of different galleries, even when combined (you can use a gallery for pick and another for crop without problems).

To see a demo go [here](https://github.com/niedev/GalleryImageSelectorExample).