### PR TITLE
Add BluetoothCommunicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Name | Repository | License
 [Retrofit](http://square.github.io/retrofit/) | https://github.com/square/retrofit | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 [RxNetty](https://github.com/ReactiveX/RxNetty) | https://github.com/ReactiveX/RxNetty | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
 [Basic HTTP Client for Java](https://code.google.com/p/basic-http-client/) | https://code.google.com/p/basic-http-client/ | [Apache License V2](https://www.apache.org/licenses/LICENSE-2.0)
+[BluetoothCommunicator](https://github.com/niedev/BluetoothCommunicator) | https://github.com/niedev/BluetoothCommunicator | [Apache License V2](https://github.com/niedev/BluetoothCommunicator/blob/master/LICENSE)
 
 ## Image Loader
 Name | Repository | License


### PR DESCRIPTION
Add BluetoothCommunicator to Networking.

BluetoothCommunicator is an open-source library that, using Bluetooth Low Energy, allows you to communicate in P2P mode between two or more android devices.

BluetoothCommunicator automatically implements (they are active by default) reconnection in case of temporary connection loss, reliable message sending, splitting and rebuilding of long messages, sending messages with a queue in order to always send the messages even in case of connection problems (they will be sent as soon as the connection is restored) and in the right order.

As a demo I created a [Bluetooth chat app](https://github.com/niedev/BluetoothCommunicatorExample) that uses this library.